### PR TITLE
Implement ResourceExecutor

### DIFF
--- a/src/dag.py
+++ b/src/dag.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Nov  5 13:19:18 2015
+
+@author: zah
+"""
+from collections import deque
+#import weakref
+
+
+class Node:
+    def __init__(self, value, inputs=None, outputs=None):
+        if inputs is None:
+            inputs = set()
+        if outputs is None:
+            outputs = set()
+
+        self.inputs = inputs
+        self.outputs = outputs
+        self.value = value
+
+    def __str__(self):
+        return "Node(%r)" % self.value
+
+    def __repr__(self):
+        return "Node(%r)" % self.value
+
+
+class DAGError(Exception): pass
+
+class CycleError(DAGError):
+    def __init__(self, node ,cycle):
+        self.node = node
+        self.cyle = cycle
+        msg = "%s introduces a cycle: %s" % (node, cycle)
+        super().__init__(msg)
+
+class DAG:
+    """A direct Acyclic graph where every node has a different value.
+    Retrieving any node can be done in constant time from its value."""
+    def __init__(self, ):
+        self._head_nodes = set()
+        self._leaf_nodes = set()
+        #Maybe we can do weakrefs in the future, but is not nice to test them
+        #without support for basic types such as str and int.
+        #We mostly care about function keys, which there isn't too much sense to
+        #weakref anyway.
+        self._node_refs = {} #weakref.WeakKeyDictionary()
+
+    def to_node(self, value):
+        return value if isinstance(value, Node) else self[value]
+
+    def to_nodes(self, values):
+        if values is None:
+            return set()
+        return {self.to_node(val) for val in values}
+
+    def add_node(self, value, inputs=None, outputs=None):
+        if value in self:
+            raise ValueError("Value already included in graph: %s" % value)
+
+        inputs, outputs = self.to_nodes(inputs), self.to_nodes(outputs)
+        n = Node(value, inputs, outputs)
+        self._node_refs[value] = n
+        if not inputs:
+            self._head_nodes.add(n)
+        else:
+            for parent in n.inputs:
+                parent.outputs.add(n)
+
+        if not outputs:
+            self._leaf_nodes.add(n)
+        else:
+            for child in n.outputs:
+                child.inputs.add(n)
+
+        self._leaf_nodes -=  n.inputs
+        self._head_nodes -=  n.outputs
+        #Check for cycles
+        visited = set()
+        for o in n.outputs:
+            now =[]
+            for u in self.deepfirst_iter(o, visited):
+                now.append(u)
+                if u == n:
+                    try:
+                        raise CycleError(n, now)
+                    finally:
+                        self.delete_node(n)
+            now = []
+
+    def delete_node(self, n):
+        del self._node_refs[n.value]
+        self._head_nodes -= {n}
+        self._leaf_nodes -= {n}
+        for parent in n.inputs:
+            parent.outputs.remove(n)
+            if not parent.outputs:
+                self._leaf_nodes.add(parent)
+
+        for child in n.outputs:
+           child.inputs.remove(n)
+           if not child.inputs:
+               self._head_nodes.add(child)
+
+
+
+    def dependency_resolver(self):
+        """Yield the nodes that have all dependencies satisfied. Send the next
+        completed task."""
+
+        can_run = {n.value for n in self._head_nodes}
+
+        blocked = {output: len(output.inputs) for node in self
+                   for output in node.outputs if output.inputs}
+
+        pending = set()
+        while True:
+            pending |= can_run
+            next_completed = yield can_run
+            try:
+                pending.remove(next_completed)
+            except KeyError:
+                raise ValueError("Sent value must be pending")
+            next_completed = self.to_node(next_completed)
+
+            if not blocked:
+                break
+
+            can_run = set()
+
+            for output in next_completed.outputs:
+                blocked[output] -= 1
+                if blocked[output] == 0:
+                    blocked.pop(output)
+                    can_run.add(output.value)
+            print(blocked)
+
+    def topological_iter(self):
+       """Simplified version of dependency resolver. Yield nodes in such an
+       order than dependencies are resolved when actions are executed
+       sequentially."""
+       can_run = deque(self._head_nodes)
+
+       blocked = {output: len(output.inputs) for node in self.deepfirst_iter()
+                   for output in node.outputs}
+
+       while can_run:
+           next_node = can_run.popleft()
+           yield next_node
+           for output in next_node.outputs:
+               blocked[output] -= 1
+               if blocked[output] == 0:
+                   blocked.pop(output)
+                   can_run.append(output)
+
+    def deepfirst_iter(self, heads=None, visited=None):
+        if heads is None:
+            heads = self._head_nodes
+        elif isinstance(heads, Node):
+            heads = {heads}
+
+        if visited is None:
+            visited = set()
+        for head in heads:
+            if head not in visited:
+                yield head
+                visited.add(head)
+                yield from self.deepfirst_iter(heads=head.outputs,
+                                            visited=visited)
+
+    def deepfirst_iter_back(self, leafs=None, visited=None):
+        if leafs is None:
+            leafs = self._leaf_nodes
+        elif isinstance(leafs, Node):
+            leafs = {leafs}
+
+        if visited is None:
+            visited = set()
+        for leaf in leafs:
+            if leaf not in visited:
+                yield leaf
+                visited.add(leaf)
+                yield from self.deepfirst_iter_back(leafs=leaf.inputs,
+                                                 visited=visited)
+
+    #While this is not recursive, we keep the same interface
+    def breadthfirst_iter(self, heads=None, visited=None):
+
+        if heads is None:
+            heads = self._head_nodes
+        elif isinstance(heads, Node):
+            heads = {heads}
+
+        if visited is None:
+            visited = set()
+
+        l = deque(heads)
+
+        while l:
+            node = l.popleft()
+            if not node in visited:
+                yield node
+                l.extend(node.outputs)
+                visited.add(node)
+
+    def breadthfirst_iter_back(self, leafs=None, visited=None):
+
+        if leafs is None:
+            leafs = self._leaf_nodes
+        elif isinstance(leafs, Node):
+            leafs = {leafs}
+
+        if visited is None:
+            visited = set()
+
+        l = deque(leafs)
+
+        while l:
+            node = l.popleft()
+            if not node in visited:
+                yield node
+                l.extend(node.inputs)
+                visited.add(node)
+
+    def __getitem__(self, value):
+        return self._node_refs[value]
+
+    def __len__(self):
+        return len(self._node_refs)
+
+
+    def __iter__(self):
+        yield from self.topological_iter()
+
+    def __contains__(self, value):
+        return value in self._node_refs

--- a/src/dag.py
+++ b/src/dag.py
@@ -20,10 +20,10 @@ class Node:
         self.value = value
 
     def __str__(self):
-        return "Node(%r)" % self.value
+        return "Node({!r})".format(self.value)
 
     def __repr__(self):
-        return "Node(%r)" % self.value
+        return "Node({!r})".format(self.value)
 
 
 class DAGError(Exception): pass

--- a/src/dag.py
+++ b/src/dag.py
@@ -134,7 +134,6 @@ class DAG:
                 if blocked[output] == 0:
                     blocked.pop(output)
                     can_run.add(output.value)
-            print(blocked)
 
     def topological_iter(self):
        """Simplified version of dependency resolver. Yield nodes in such an

--- a/src/dag.py
+++ b/src/dag.py
@@ -72,14 +72,14 @@ class DAG:
     def _wire_node(self, n):
         """Update data structures taking into account the new state of
         node ``n``."""
-        inputs, outputs = n.inputs, n.outputs
-        if not inputs:
+
+        if not n.inputs:
             self._head_nodes.add(n)
         else:
             for parent in n.inputs:
                 parent.outputs.add(n)
 
-        if not outputs:
+        if not n.outputs:
             self._leaf_nodes.add(n)
         else:
             for child in n.outputs:
@@ -88,14 +88,16 @@ class DAG:
         self._leaf_nodes -=  n.inputs
         self._head_nodes -=  n.outputs
         #Check for cycles
-        visited = set()
-        for o in n.outputs:
-            now =[]
-            for u in self.deepfirst_iter(o, visited):
-                now.append(u)
-                if u == n:
-                    raise CycleError(n, now)
-            now = []
+        #if we have no inputs and no outputs we cannot create a cycle.
+        if n.inputs and n.outputs:
+            visited = set()
+            for o in n.outputs:
+                now =[]
+                for u in self.deepfirst_iter(o, visited):
+                    now.append(u)
+                    if u == n:
+                        raise CycleError(n, now)
+                now = []
 
 
     def add_or_update_node(self, value, inputs=None, outputs=None):

--- a/src/resourcebuilder.py
+++ b/src/resourcebuilder.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Nov 13 21:18:06 2015
+
+@author: zah
+"""
+
+from collections import namedtuple
+from functools import partial
+from concurrent.futures import ProcessPoolExecutor
+
+import asyncio
+
+CallSpec = namedtuple("CallSpec", "function kwargs resultname".split())
+
+class ResourceExecutor():
+
+    def __init__(self, graph, namespace):
+        self.graph = graph
+        self.namespace = namespace
+
+
+    def execute_sequential(self):
+        for node in self.graph:
+            function, kwargs, resultname = node.value
+            kwdict = {kw: self.namespace[kw] for kw in kwargs}
+            self.namespace[resultname] = function(**kwdict)
+
+    async def submit_next_specs(self, loop, executor, next_specs, deps):
+
+        futures = []
+        for spec in next_specs:
+            kwdict = {kw: self.namespace[kw] for kw in spec.kwargs}
+            clause = partial(spec.function, **kwdict)
+            future = loop.run_in_executor(executor, clause)
+            callback = partial(self._spec_done, 
+                               loop=loop, executor=executor, 
+                               spec=spec, deps=deps)
+            future.add_done_callback(callback)
+
+            futures.append(future)
+        for future in futures:
+            await future
+
+    def _spec_done(self, future, loop, executor, spec, deps):
+        self.namespace[spec.resultname] = future.result()
+        try:
+            next_specs = deps.send(spec)
+        except StopIteration:
+            loop.stop()
+        else:
+            loop.create_task(self.submit_next_specs(loop, executor, 
+                                                    next_specs, deps))
+
+    def execute_parallel(self, executor=None, loop=None):
+
+        if executor is None:
+            executor = ProcessPoolExecutor()
+        if loop is None:
+            loop = asyncio.get_event_loop()
+
+        deps = self.graph.dependency_resolver()
+        next_specs = deps.send(None)
+        
+        with executor:
+            loop.create_task(self.submit_next_specs(loop, executor, 
+                                                    next_specs, deps))
+            loop.run_forever()

--- a/src/resourcebuilder.py
+++ b/src/resourcebuilder.py
@@ -8,10 +8,16 @@ Created on Fri Nov 13 21:18:06 2015
 from collections import namedtuple
 from functools import partial
 from concurrent.futures import ProcessPoolExecutor
-
 import asyncio
 
 CallSpec = namedtuple("CallSpec", "function kwargs resultname".split())
+
+def print_callspec(spec):
+    callargs = ', '.join("%s=%s"% (kw, kw) for kw in spec.kwargs)
+    return "{res} = {f}({callargs})".format(res=spec.resultname,
+                                        f=spec.function.__qualname__,
+                                        callargs=callargs)
+
 
 class ResourceExecutor():
 
@@ -66,3 +72,6 @@ class ResourceExecutor():
             loop.create_task(self.submit_next_specs(loop, executor, 
                                                     next_specs, deps))
             loop.run_forever()
+
+    def __str__(self):
+        return "\n".join(print_callspec(node.value) for node in self.graph)

--- a/src/tests/test_dag.py
+++ b/src/tests/test_dag.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Nov 13 15:01:41 2015
+
+@author: zah
+"""
+
+
+import unittest
+
+from dag import DAG, CycleError
+
+class TestDAG(unittest.TestCase):
+
+    @staticmethod
+    def make_diamond():
+        g = DAG()
+        g.add_node(0)
+        g.add_node(1, inputs={0})
+        g.add_node(2, inputs={0})
+        g.add_node(3, inputs={1,2})
+
+        return g
+
+    def make_graphs(self):
+        return [self.make_diamond()]
+
+    def test_add(self):
+        g = DAG()
+        g.add_node(1)
+        g.add_node(2)
+        g.add_node(3, inputs = {1,2})
+        g.add_node(0, outputs={1})
+        self.assertEqual(g._head_nodes, g.to_nodes({0,2}))
+        self.assertEqual(g._leaf_nodes, g.to_nodes({3}))
+
+    def test_inter(self):
+        for g in self.make_graphs():
+            self.assertEqual(len(set(g)), len(list(g)))
+
+    def test_diamond(self):
+
+        g = self.make_diamond()
+        first_child = {o for node in g._head_nodes for o in node.outputs}
+        self.assertEqual(first_child, g.to_nodes({1,2}))
+
+        nodes = list(g.topological_iter())
+        self.assertEqual({nodes[0]}, g.to_nodes({0}))
+        self.assertEqual(set(nodes[1:3]), g.to_nodes({1,2}))
+        self.assertEqual({nodes[3]}, g.to_nodes({3}))
+
+        nodes = list(g.breadthfirst_iter())
+        self.assertEqual({nodes[0]}, g.to_nodes({0}))
+        self.assertEqual(set(nodes[1:3]), g.to_nodes({1,2}))
+        self.assertEqual({nodes[3]}, g.to_nodes({3}))
+
+        nodes = list(g.deepfirst_iter())
+        self.assertEqual({nodes[0]}, g.to_nodes({0}))
+        self.assertEqual({nodes[2]}, g.to_nodes({3}))
+
+    def test_cycles(self):
+        g = self.make_diamond()
+        refs =g._node_refs.copy()
+        with self.assertRaises(CycleError):
+            g.add_node(5, inputs={3}, outputs={0})
+        self.assertNotIn(5, g)
+        self.assertEqual(refs, g._node_refs)
+
+    def test_dependency_resolver(self):
+        g = self.make_diamond()
+        resolver = g.dependency_resolver()
+        self.assertEqual(resolver.send(None), {0})
+        self.assertEqual(resolver.send(0), {1,2})
+        self.assertEqual(resolver.send(1), set())
+        self.assertEqual(resolver.send(2), {3})
+
+        resolver = g.dependency_resolver()
+        resolver.send(None)
+        resolver.send(0)
+        resolver.send(1)
+        with self.assertRaises(ValueError):
+            resolver.send(1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_dag.py
+++ b/src/tests/test_dag.py
@@ -34,6 +34,21 @@ class TestDAG(unittest.TestCase):
         self.assertEqual(g._head_nodes, g.to_nodes({0,2}))
         self.assertEqual(g._leaf_nodes, g.to_nodes({3}))
 
+    def test_add_update(self):
+        g = DAG()
+        g.add_or_update_node(1)
+        g.add_or_update_node(2)
+        g.add_or_update_node(3, inputs = {1,2})
+        g.add_or_update_node(0, outputs={1})
+        self.assertEqual(g._head_nodes, g.to_nodes({0,2}))
+        self.assertEqual(g._leaf_nodes, g.to_nodes({3}))
+
+        g.add_or_update_node(0, outputs={1,2,3})
+        with self.assertRaises(CycleError):
+            g.add_or_update_node(0, inputs={1})
+
+        self.assertEqual(g[0].outputs, g.to_nodes({1,2,3}))
+
     def test_inter(self):
         for g in self.make_graphs():
             self.assertEqual(len(set(g)), len(list(g)))

--- a/src/tests/test_executor.py
+++ b/src/tests/test_executor.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Nov 13 22:51:32 2015
+
+@author: zah
+"""
+
+import unittest
+import time
+
+from dag import DAG
+from resourcebuilder import ResourceExecutor, CallSpec
+
+def f(param):
+    print("Executing f")
+    time.sleep(1)
+    return "fresult: %s" % param
+
+def g(fresult):
+    print("Executing g")
+    time.sleep(2)
+    return fresult*2
+
+def h(fresult):
+    print("Executing h")
+    time.sleep(2)
+    return fresult*3
+
+def m(gresult, hresult, param=None):
+    print("executing m")
+    return (gresult+hresult)*(param//2)
+
+class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
+    def setUp(self):
+        self.namespace = {'param':4}
+        self.graph = DAG()
+        fcall = CallSpec(f, ('param',), 'fresult')
+        gcall = CallSpec(g, ('fresult',), 'gresult')
+        hcall = CallSpec(h, ('fresult',), 'hresult')
+        mcall = CallSpec(m, ('gresult','hresult','param'), 'mresult')
+        
+        self.graph.add_node(fcall)
+        self.graph.add_node(gcall, inputs={fcall})
+        self.graph.add_node(hcall, inputs={fcall})
+        self.graph.add_node(mcall, inputs={gcall, hcall})
+    
+    def test_seq_execute(self):
+        self.execute_sequential()
+        self.assertEqual(self.namespace['mresult'], 'fresult: 4'*10)
+    
+    def test_parallel_execute(self):
+        self.execute_parallel()
+        self.assertEqual(self.namespace['mresult'], 'fresult: 4'*10)
+
+if __name__ =='__main__':
+    unittest.main()


### PR DESCRIPTION
This takes a DAG of "`CallSpec`s", and executes in a given namespace. There
are two methods of executing: either sequentially or in parallel. The
sequential implementation is very straightforward and is only 4 lines of
code. The parallel one is more complex. It uses the new Python 3.5 syntax
(that we target Python >= 3.5 is already stated in the doc). By default
each task is executed in a pool of processes and a subsequent task is
scheduled to run as soon as its dependencies are met.

Maybe we could use a decorator to specify whether a task is going to run in
another process or in the main one (blocking it but avoiding the cost of
serializing inputs and outputs and sending them by IPC).

The same implementation could be used to execute the tasks in different
nodes of a cluster, by supplying the appropriate executor.