### PR TITLE
minor change as a global workaround for NNPDF/nnpdf#363 

### DIFF
--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -63,7 +63,8 @@ def savefig(fig, *, paths, output ,suffix=''):
 
         #Numpy can produce a lot of warnings while working on producing figures
         with np.errstate(invalid='ignore'):
-            fig.savefig(str(path), bbox_inches='tight')
+            fig.tight_layout()
+            fig.savefig(str(path))
         outpaths.append(path.relative_to(output))
     plt.close(fig)
     return Figure(outpaths)


### PR DESCRIPTION
See matplotlib/matplotlib/#13276

The 3.0.2 fix of matplotlib/matplotlib#12648 (by PR https://github.com/matplotlib/matplotlib/pull/12651) appears to only affect `plt.tight_layout()`, not the kwarg `bbox_inches='tight'` (see matplotlib/matplotlib#13276). This minor change means that users who have MPL 3.0.2 installed shouldn't encounter issues caused by annotations with NaN position.

It will also be accompanied by a PR in NNPDF/nnpdf which tries to avoid creating annotations with NaN positions