### PR TITLE
Adding ability to cache general function returns

### DIFF
--- a/src/reportengine/caching.py
+++ b/src/reportengine/caching.py
@@ -8,7 +8,7 @@ def cache_to_file(directory: str="/tmp"):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            suffix = pathlib.Path(func.__name__ + "(" + str(args) + ", "+ str(kwargs) + ")")
+            suffix = pathlib.Path(str(hash(func.__name__ + "(" + str(args) + ", "+ str(kwargs) + ")")))
             cache_file = path / suffix
 
             if cache_file.exists():

--- a/src/reportengine/caching.py
+++ b/src/reportengine/caching.py
@@ -8,7 +8,8 @@ def cache_to_file(directory: str="/tmp"):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            suffix = pathlib.Path(str(hash(func.__name__ + "(" + str(args) + ", "+ str(kwargs) + ")")))
+            suffix = func.__name__ + "(" + str(args) + ", "+ str(kwargs) + ")"
+            suffix = pathlib.Path(suffix.replace("/", ""))
             cache_file = path / suffix
 
             if cache_file.exists():

--- a/src/reportengine/caching.py
+++ b/src/reportengine/caching.py
@@ -1,0 +1,27 @@
+import functools
+import pathlib
+import pickle
+
+def cache_to_file(directory: str="/tmp"):
+    def inner(func):
+        path = pathlib.Path(directory)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            suffix = pathlib.Path(func.__name__ + "(" + str(args) + ", "+ str(kwargs) + ")")
+            cache_file = path / suffix
+
+            if cache_file.exists():
+                with open(cache_file, "rb") as in_stream:
+                    cached_args, cached_kwargs, cached_result = pickle.load(in_stream)
+                if cached_args == args and cached_kwargs == kwargs:
+                    result = cached_result
+            else:
+                result = func(*args, **kwargs)
+                with open(cache_file, 'wb') as out_stream:
+                    to_cache = (args, kwargs, result)
+                    pickle.dump(to_cache, out_stream, pickle.HIGHEST_PROTOCOL)
+
+            return result
+        return wrapper
+    return inner


### PR DESCRIPTION
So I found it really annoying where I had `vp` functions that would constantly do the exact same thing but take absolutely ages.

I've written a wrapper that basically caches function returns as pickle objects. I'm happy to delete this if people deem it not to be unnecessary.

Basic usage is as follows:
```python
In [1]: from reportengine.caching import cache_to_file                             

In [2]: @cache_to_file() 
   ...: def square(iterable): 
   ...:     return [i**2 for i in iterable] 
   ...:                                                                            

In [3]: square([1,2,3,4])                                                          
Out[3]: [1, 4, 9, 16]
```
And if you check `/tmp` (default) you should have a file `'square(([1, 2, 3, 4],), {})'` that cache'd the result.

If we want to keep it I'll write proper doc strings for merging.