### PR TITLE
add an id= field to figures

### DIFF
--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -26,7 +26,7 @@ import logging
 
 import numpy as np
 
-from reportengine.formattingtools import  spec_to_nice_name
+from reportengine.formattingtools import spec_to_nice_name
 from reportengine.utils import add_highlight, normalize_name
 
 __all__ = ['figure', 'figuregen']
@@ -40,7 +40,9 @@ class Figure():
     @property
     def as_markdown(self):
         links = ' '.join('[{ext}]({path})'.format(ext=path.suffix, path=path) for path in self.paths)
-        return '![{1}]({0})\n'.format(self.paths[0], links)
+        base_path = self.paths[0]
+        retmd = '![{0}]({1}){{#{2}}} \n'.format(links, base_path, base_path.stem)
+        return retmd
 
 
 def prepare_paths(*,spec, namespace, environment ,**kwargs):

--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -33,7 +33,7 @@ __all__ = ['figure', 'figuregen']
 
 log = logging.getLogger(__name__)
 
-def _generate_markdown_link(path, caption = None):
+def _generate_markdown_link(path, caption=None):
     if caption is None:
         caption = path.suffix
     return f"[{caption}]({path})"
@@ -46,11 +46,11 @@ class Figure():
     @property
     def as_markdown(self):
         # Prepare the anchor
-        anchor_link = self.paths[0].stem
-        links = _generate_markdown_link(f"#{anchor_link}", "anchor") + " "
+        anchor_link_target = f'#{self.paths[0].stem}'
         # Prepare the link to the actual figures
-        links += ' '.join(_generate_markdown_link(path) for path in self.paths)
-        retmd = '![{0}]({1}){{#{2}}} \n'.format(links, self.paths[0], anchor_link)
+        links = ' '.join(_generate_markdown_link(path) for path in self.paths) + ' '
+        links += _generate_markdown_link(anchor_link_target, "#")
+        retmd = f'![{links}]({self.paths[0]}){{{anchor_link_target}}} \n'
         return retmd
 
 

--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -33,15 +33,24 @@ __all__ = ['figure', 'figuregen']
 
 log = logging.getLogger(__name__)
 
+def _generate_markdown_link(path, caption = None):
+    if caption is None:
+        caption = path.suffix
+    return f"[{caption}]({path})"
+
+
 class Figure():
     def __init__(self, paths):
         self.paths = paths
 
     @property
     def as_markdown(self):
-        links = ' '.join('[{ext}]({path})'.format(ext=path.suffix, path=path) for path in self.paths)
-        base_path = self.paths[0]
-        retmd = '![{0}]({1}){{#{2}}} \n'.format(links, base_path, base_path.stem)
+        # Prepare the anchor
+        anchor_link = self.paths[0].stem
+        links = _generate_markdown_link(f"#{anchor_link}", "anchor") + " "
+        # Prepare the link to the actual figures
+        links += ' '.join(_generate_markdown_link(path) for path in self.paths)
+        retmd = '![{0}]({1}){{#{2}}} \n'.format(links, self.paths[0], anchor_link)
         return retmd
 
 


### PR DESCRIPTION
One thing that I find myself doing a lot with reports is linking to a specific parton or dataset, so having an "id=" field in the figure allows you to do it while still having the rest of the images in the same page.

`
{www.validphyserver.org}/pdf_report_report.html#pdf_report_pdfnormalize0_basespecs0_pdfscalespecs0_plot_pdfs_s`