### PR TITLE
Split up plots into columns in vp reports

### DIFF
--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -97,12 +97,12 @@ def savefiglist(figures, paths, output):
             str(p.with_name('_'.join((p.stem, suffix)) + p.suffix)) for p in p_base
         ]
         ref = savefig(fig, paths=paths, output=output, suffix=suffix)
-        html = f"""<p style="float: left; text-align: center; width: 50%">
-                   <img src={p_full[0]} style="width: 100%">
+        html = f"""<p class="half_page_width">
+                   <img src={p_full[0]}>
                    <a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a>
                    </p>"""
         if i % 2 == 1:
-            html += '<br style="clear:both"/>'
+            html += '<br style="clear: both"/>'
         res.append(html)
     return res
 

--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -93,11 +93,16 @@ def savefiglist(figures, paths, output):
             suffix = str(i)
         suffix = normalize_name(suffix)
         p_base = [paths[i].relative_to(output) for i in range(len(paths))]
-        p_full = [str(p.with_name('_'.join((p.stem, suffix)) + p.suffix)) for p in p_base]
+        p_full = [
+            str(p.with_name('_'.join((p.stem, suffix)) + p.suffix)) for p in p_base
+        ]
         ref = savefig(fig, paths=paths, output=output, suffix=suffix)
-        html = f'<p style="float: left; text-align: center; width: 50%"><img src={p_full[0]} style="width: 100%"><a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a></p>'
-        if i%2==1:
-            html += '<br style="clear:both" />'
+        html = f"""<p style="float: left; text-align: center; width: 50%">
+                   <img src={p_full[0]} style="width: 100%">
+                   <a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a>
+                   </p>"""
+        if i % 2 == 1:
+            html += '<br style="clear:both"/>'
         res.append(html)
     return res
 

--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -97,10 +97,12 @@ def savefiglist(figures, paths, output):
             str(p.with_name('_'.join((p.stem, suffix)) + p.suffix)) for p in p_base
         ]
         ref = savefig(fig, paths=paths, output=output, suffix=suffix)
-        html = f"""<p class="half_page_width">
-                   <img src={p_full[0]}>
-                   <a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a>
-                   </p>"""
+        html = (
+            f'\n<p class="half_page_width">'
+            f'<img src={p_full[0]}>'
+            f'<a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a>'
+            '</p>\n'
+        )
         if i % 2 == 1:
             html += '<br style="clear: both"/>'
         res.append(html)

--- a/src/reportengine/figure.py
+++ b/src/reportengine/figure.py
@@ -91,7 +91,14 @@ def savefiglist(figures, paths, output):
             fig, suffix = fig
         else:
             suffix = str(i)
-        res.append(savefig(fig, paths=paths, output=output, suffix=suffix))
+        suffix = normalize_name(suffix)
+        p_base = [paths[i].relative_to(output) for i in range(len(paths))]
+        p_full = [str(p.with_name('_'.join((p.stem, suffix)) + p.suffix)) for p in p_base]
+        ref = savefig(fig, paths=paths, output=output, suffix=suffix)
+        html = f'<p style="float: left; text-align: center; width: 50%"><img src={p_full[0]} style="width: 100%"><a href={p_full[0]}>.png</a> <a href={p_full[1]}>.pdf</a></p>'
+        if i%2==1:
+            html += '<br style="clear:both" />'
+        res.append(html)
     return res
 
 

--- a/src/reportengine/styles/report.css
+++ b/src/reportengine/styles/report.css
@@ -63,3 +63,9 @@ body figcaption {
 .container {
   max-width: 1200px;
 }
+
+.half_page_width {
+  float: left;
+  text-align: center;
+  width: 50%;
+}


### PR DESCRIPTION
Works towards closing https://github.com/NNPDF/nnpdf/issues/268. So far it works for the 'PDF plots' section of the vp-comparefits report (https://vp.nnpdf.science/KbFpz1hOQwKsPbFVaDtqew==/pdf_report_report.html), i.e. for the PDF plots and the effective exponents. Personally I think it's much more readable with this formatting and the PDF plots page being shorter is certainly nicer. I think the same formatting should be applied to the other plots in the report too: namely distances, arc lengths, training-validation splits, and positivity plots. Let me know if you have any thoughts