### PR TITLE
Add pip command to readme and a list of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ conda build conda-recipe
 
 and then installing the resulting package.
 
+It is also possible to install the latest version from git with
+
+````
+pip install --upgrade git+https://github.com/NNPDF/reportengine.git
+````
+
 
 Development
 -----------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pandas >=1
 pygments
 blessings
 curio ==0.9
-pandoc >=2.0a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+jinja2
+ruamel_yaml
+matplotlib
+pandas >=1
+pygments
+blessings
+curio ==0.9
+pandoc >=2.0a

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ if sys.version_info < (3,6):
 with open("README.md") as f:
     long_desc = f.read()
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 setup (name = 'reportengine',
        version = '0.5',
@@ -25,6 +27,7 @@ setup (name = 'reportengine',
        package_data = {
             '':['*.template', '*.mplstyle', '*.md', '*.css']
        },
+       install_requires = requirements,
        zip_safe = False,
        classifiers=[
             'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
As the title suggest, this commit adds the possibility of installing reportengine with pip directly from github so that dependencies are automatically installed.