### PR TITLE
Saving tables as parquet

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,11 +20,12 @@ requirements:
     - jinja2
     - ruamel_yaml =0.15
     - matplotlib
-    - pandas >=1
+    - pandas >=1.2.0
     - pygments
     - blessings
     - curio
     - pandoc >=2
+    - pyarrow
 
 test:
     requires:

--- a/src/reportengine/table.py
+++ b/src/reportengine/table.py
@@ -64,10 +64,28 @@ def prepare_path(*, spec, namespace,environment, **kwargs):
     path = environment.table_folder / (name + '.csv')
     return {'path': path}
 
-def savetable(df, path):
+def savetable(df, path, format=None):
     """Final action to save figures, with a nice filename"""
     log.debug("Writing table %s" % path)
-    df.to_csv(str(path), sep='\t', na_rep='nan')
+
+    if format in (None, "parquet"): # Default to parquet format
+        # Need to change the type of each level to str
+        log.debug("Changing column types to str")
+        cols = df.columns
+        for i in range(cols.nlevels):
+            str_col = cols.levels[i].astype(str)
+            # Could use inplace but it's
+            # going to bedeprecated
+            cols = cols.set_levels(str_col, i) 
+        df.columns = cols
+        df.to_parquet(str(path))
+    elif format == "csv":
+        df.to_csv(str(path), sep='\t', na_rep='nan')
+    else:
+        raise NotImplementedError(
+            f"Unrecognised format {format}",
+            "choose one of parquet or csv"
+        )
     return Table.fromdf(df, path=path)
 
 def savetablelist(dfs, path):


### PR DESCRIPTION
Requires pandas 1.2.0 to save [multi index df's](https://github.com/pandas-dev/pandas/pull/36305/files)

also needs the columns to be changed to `str` but that should be fine. Other than that, it works really nicely

p.s it'd be nice to do editable installs, feels like im coding with c++ using this flint thing