### PR TITLE
Allow loading extra modules from path

### DIFF
--- a/src/reportengine/app.py
+++ b/src/reportengine/app.py
@@ -21,7 +21,7 @@ from reportengine.resourcebuilder import ResourceBuilder, ResourceError
 from reportengine.configparser import ConfigError, Config
 from reportengine.environment import Environment, EnvironmentError_
 from reportengine.baseexceptions import ErrorWithAlternatives
-from reportengine.utils import get_providers
+from reportengine.utils import get_providers, import_from_path
 from reportengine import colors
 from reportengine import helputils
 
@@ -207,11 +207,15 @@ class App:
         providers = []
         for mod in maybe_names:
             if isinstance(mod, str):
-                try:
-                    mod = importlib.import_module(mod)
-                except ImportError:
-                    log.error("Could not import module %s", mod)
-                    raise
+                if pathlib.Path(mod).is_file():
+                    log.debug("Loading %s from path location", mod)
+                    mod = import_from_path(mod)
+                else:
+                    try:
+                        mod = importlib.import_module(mod)
+                    except ImportError:
+                        log.error("Could not import module %s", mod)
+                        raise
             providers.append(mod)
         return providers
 

--- a/src/reportengine/utils.py
+++ b/src/reportengine/utils.py
@@ -7,6 +7,8 @@ import collections
 import pickle
 import inspect
 import re
+import importlib.util
+import pathlib
 
 #TODO: Support metaclass attributes?
 def get_classmembers(cls, *, predicate=None):
@@ -114,3 +116,12 @@ def ordinal(n):
     else:
         suffix = ('st', 'nd', 'rd')[residual - 1]
     return '%d%s' % (n,suffix)
+
+def import_from_path(path):
+    """Import a module given a path location"""
+    # See https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path#comment104641985_67631
+    path = pathlib.Path(path)
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod


### PR DESCRIPTION
It is sometimes useful to add the extra_modules feature, for example to
add a couple of plots to a paper. For that is rather inconvenient to
have to install the module properly in the Python path and it is easier
to just pass a file.