### PR TITLE
Force fuzzyspec expansion to always resolve the ns

### DIFF
--- a/src/reportengine/resourcebuilder.py
+++ b/src/reportengine/resourcebuilder.py
@@ -402,11 +402,16 @@ class ResourceBuilder(ResourceExecutor):
 
         log.debug("Processing requirement: %s" % (name,))
 
+
         ns = namespaces.resolve(self.rootns, nsspec)
         if extraargs is None:
             extraargs = ()
 
-
+        is_provider = self.is_provider_func(name)
+        if ( is_provider and isinstance(self.get_provider_func(name), collect)):
+            log.debug("Resolving collect node for %s", name)
+            yield from self._make_node(name, nsspec, extraargs, parents)
+            return
         #First try to find the name in the namespace
         try:
             put_index, val = self.input_parser.resolve_key(name, ns, parents=parents, currspec=nsspec)

--- a/src/reportengine/tests/test_complexinput.py
+++ b/src/reportengine/tests/test_complexinput.py
@@ -181,6 +181,9 @@ class Config(configparser.Config):
         res.sort(key=lambda x: (x['dataset_name']))
         return res
 
+    def produce_dependent_namespace(self, pdf):
+        return {"pdfprop": pdf}
+
 
 @make_argcheck
 def bad_check(pdf):
@@ -193,8 +196,14 @@ class Providers:
     def plot_a_pdf(self, pdf):
         return "PLOT OF " + str(pdf)
 
+    def prop_table(self, pdfprop):
+        return f"Table: {pdfprop}"
+
     dataspecs_speclabel = collect('speclabel', ('datasepcs',),
                                   element_default='label')
+
+    props_collection = collect("prop_table", ("dependent_namespace",))
+
     @bad_check
     def bad_plot(self, pdf):
         return self.plot_a_pdf(pdf)
@@ -398,6 +407,21 @@ class TestSpec(unittest.TestCase):
         ds2 = namespaces.resolve(builder.rootns,
                 (('matched_datasets_from_dataspecs', 0), ('dataspecs', 1),))['dataset']
         assert ds1 != ds2
+
+    def test_dependent_rules(self):
+        c = Config({"pdf": "a", "Ns": {"pdf": "b"}})
+        targets = [
+            FuzzyTarget("props_collection", (), (), ()),
+            FuzzyTarget("props_collection", ("Ns",), (), ()),
+        ]
+        builder = resourcebuilder.ResourceBuilder(c, Providers(), targets)
+        builder.resolve_fuzzytargets()
+        builder.execute_sequential()
+        res1 = namespaces.resolve(builder.rootns, ())["props_collection"]
+        res2 = namespaces.resolve(builder.rootns, ('Ns',))["props_collection"]
+        assert res1 == ['Table: PDF: a']
+        assert res2 == ['Table: PDF: b']
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/reportengine/tests/test_namespaces.py
+++ b/src/reportengine/tests/test_namespaces.py
@@ -52,52 +52,26 @@ class TestNamespaces(unittest.TestCase):
     def test_expand(self):
         fuzzy = ('a', 'c')
         ns = ChainMap(self.d)
-        gen = namespaces.expand_fuzzyspec_partial(ns, fuzzy)
-        #self.assertFalse(list(gen))
-        while True:
-            try:
-                next(gen)
-            except StopIteration as e:
-                self.assertEqual(e.value, [('a', ('c', 0)), ('a', ('c', 1))])
-                break
-            else:
-                self.fail()
+        assert namespaces.expand_fuzzyspec(ns, fuzzy) == [
+            ('a', ('c', 0)),
+            ('a', ('c', 1)),
+        ]
 
-        fuzzy = ('a', 'x', 'c')
-        ns = ChainMap(self.d)
-        gen = namespaces.expand_fuzzyspec_partial(ns, fuzzy)
-        #self.assertFalse(list(gen))
-        var, spec, cns = next(gen)
-        cns[var] = 'not ok'
-        with self.assertRaises(TypeError):
-            next(gen)
-
-        fuzzy = ('a', 'xx', 'c')
-        ns = ChainMap(self.d)
-        gen = namespaces.expand_fuzzyspec_partial(ns, fuzzy)
-        #self.assertFalse(list(gen))
-        var, spec, cns = next(gen)
-        cns[var] = [{'ok': True}, {'ok':'yes'}, {'ok':1}]
-        with self.assertRaises(StopIteration) as ec:
-            next(gen)
-        specs = ec.exception.value
-        self.assertEqual(set(specs),
-             set(itertools.product('a', [('xx', 0), ('xx', 1,), ('xx', 2)],
-                                         [('c', 0), ('c', 1)]))
-        )
 
     def test_nested_expand(self):
         d = self.d
-        d['c'][0]['l3'] = [{'x':1},{'x':2}]
-        d['c'][1]['l3'] = [{'x':1},]
+        d['c'][0]['l3'] = [{'x': 1}, {'x': 2}]
+        d['c'][1]['l3'] = [
+            {'x': 1},
+        ]
         ns = ChainMap(d)
         fuzzy = ('c', 'l3')
-        gen = namespaces.expand_fuzzyspec_partial(ns, fuzzy)
-        with self.assertRaises(StopIteration) as ec:
-            next(gen)
-        self.assertEqual(ec.exception.value,
-         [(('c', 0), ('l3', 0)), (('c', 0), ('l3', 1)), (('c', 1), ('l3', 0))]
-        )
+        res = namespaces.expand_fuzzyspec(ns, fuzzy)
+        assert res == [
+            (('c', 0), ('l3', 0)),
+            (('c', 0), ('l3', 1)),
+            (('c', 1), ('l3', 0)),
+        ]
 
     def test_identities(self):
         a = {1:'a'}
@@ -118,12 +92,7 @@ class TestNamespaces(unittest.TestCase):
         l1cp = copy.deepcopy(l1)
         d = {'root': root, 'l1':l1, 'l2':l2}
 
-        try:
-            next(namespaces.expand_fuzzyspec_partial(d, ('root', 'l1', 'l2')))
-        except StopIteration as e:
-            specs = e.value
-        else:
-            raise RuntimeError()
+        specs = namespaces.expand_fuzzyspec(d, ('root', 'l1', 'l2'))
 
 
         self.assertEqual(len(specs), 3*3)


### PR DESCRIPTION
If a namespace depends on a production rule (e.g. one that returns
a dictionary or list of dictionaries that are then used in collect) the
namespace would be resolved once but then be oblivious to the changes in
the input of the production rule, that would make it required to
reevaluate it.

Rather than adding more special cases, just force all keys to be
revaluated by the config object so as to keep them up to date within the
current namespace. I cannot think of many downsides to this change,
other than having to needlessly reevaluate a few inputs (which are
assumed to be cheap in the first place).

The test in test_complexinput.py represents a minimal example of input
that would fail in master and work correctly with this change.
