### PR TITLE
Add folder_prefix option

### DIFF
--- a/src/reportengine/app.py
+++ b/src/reportengine/app.py
@@ -192,6 +192,12 @@ class App:
         parallel.add_argument('--no-parallel', dest='parallel',
                               action='store_false')
 
+        parser.add_argument(
+            '--folder-prefix',
+            action='store_true',
+            help="add a prefix derived from the runcard name to ourput resources.",
+        )
+
         parser.add_argument('-h', '--help', action=ArgumentHelpAction,
                             app=self)
 

--- a/src/reportengine/app.py
+++ b/src/reportengine/app.py
@@ -195,7 +195,7 @@ class App:
         parser.add_argument(
             '--folder-prefix',
             action='store_true',
-            help="add a prefix derived from the runcard name to ourput resources.",
+            help="add a prefix derived from the runcard name to output resources.",
         )
 
         parser.add_argument('-h', '--help', action=ArgumentHelpAction,

--- a/src/reportengine/app.py
+++ b/src/reportengine/app.py
@@ -182,6 +182,10 @@ class App:
                             help="additional providers from which to "
                             "load actions. Must be an importable specifiaction.")
 
+        parser.add_argument('--dry',
+                          help = "Perform only the runcard checks without executing the actions.",
+                          action='store_true')
+
         parallel = parser.add_mutually_exclusive_group()
         parallel.add_argument('--parallel', action='store_true',
                               help="execute actions in parallel")
@@ -356,10 +360,13 @@ class App:
                 traceback_if_debug(e)
             sys.exit(1)
 
-        c.dump_lockfile()
-
-        log.info("All requirements processed and checked successfully. "
-        "Executing actions.")
+        if self.args['dry']:
+            log.info("All requirements processed and checked successfully. ")
+            return
+        else:
+            c.dump_lockfile()
+            log.info("All requirements processed and checked successfully. "
+            "Executing actions.")
 
         if parallel:
             rb.execute_parallel()

--- a/src/reportengine/environment.py
+++ b/src/reportengine/environment.py
@@ -122,7 +122,7 @@ class Environment:
         return dict(
             output_path = "Folder where the results are to be written.",
             config_rel_path = cls.config_rel_path.__doc__,
-            filename_prefix = "Prefix for to prepend to filenames",
+            filename_prefix = "Prefix prepended to filenames",
         )
 
     def ns_dump(self):

--- a/src/reportengine/environment.py
+++ b/src/reportengine/environment.py
@@ -33,6 +33,7 @@ class Environment:
     def __init__(self, *, output=None, formats=('pdf',),
                  default_figure_format=None, loglevel=logging.DEBUG,
                  config_yml = None,
+                 folder_prefix=False,
                  **kwargs):
         if output:
             self.output_path = pathlib.Path(output).absolute()
@@ -43,6 +44,11 @@ class Environment:
         self.loglevel = loglevel
         self.extra_args = kwargs
         self.config_yml = config_yml
+        if folder_prefix and config_yml:
+            self.filename_prefix = pathlib.Path(config_yml).stem
+        else:
+            self.filename_prefix = None
+
 
     @property
     def figure_formats(self):
@@ -116,7 +122,7 @@ class Environment:
         return dict(
             output_path = "Folder where the results are to be written.",
             config_rel_path = cls.config_rel_path.__doc__,
-
+            filename_prefix = "Prefix for to prepend to filenames",
         )
 
     def ns_dump(self):

--- a/src/reportengine/formattingtools.py
+++ b/src/reportengine/formattingtools.py
@@ -27,6 +27,9 @@ def get_nice_name(ns, nsspec, suffix=None):
     (see the ``namespaces`` documentation for more details)"""
     parts = []
     currspec = []
+    prefix = ns.get("filename_prefix", None)
+    if prefix:
+        parts.append(prefix)
     currns = ns
     for ele in nsspec:
         currspec.append(ele)


### PR DESCRIPTION
Add an option to add a prefix to figures and tables that are named
automatically.

I decided against modifying the default output  folder name because the
interaction with the existing -o option is a bit  weird, and it is easy
enough to pass it.

Closes #50.