### PR TITLE
default style as environment property

### DIFF
--- a/src/reportengine/app.py
+++ b/src/reportengine/app.py
@@ -282,6 +282,13 @@ class App:
         #DO NOT remove this unless you know Qt to work properly with LHAPDF.
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
+        try:
+            env = self.make_environment(args)
+        except EnvironmentError_ as e:
+            traceback_if_debug(e)
+            log.error(e)
+            sys.exit(1)
+
         if args.get('style', False):
             try:
                 plt.style.use(args['style'])
@@ -289,8 +296,8 @@ class App:
                 log.error(f"There was a problem reading the supplied style: {e}",
                      )
                 sys.exit(1)
-        elif self.default_style:
-            plt.style.use(self.default_style)
+        else:
+            plt.style.use(env.default_style)
 
 
     def init(self, cmdline=None):

--- a/src/reportengine/environment.py
+++ b/src/reportengine/environment.py
@@ -34,6 +34,7 @@ class Environment:
                  default_figure_format=None, loglevel=logging.DEBUG,
                  config_yml = None,
                  folder_prefix=False,
+                 default_style = None,
                  **kwargs):
         if output:
             self.output_path = pathlib.Path(output).absolute()
@@ -44,11 +45,20 @@ class Environment:
         self.loglevel = loglevel
         self.extra_args = kwargs
         self.config_yml = config_yml
+        self._default_style = default_style
         if folder_prefix and config_yml:
             self.filename_prefix = pathlib.Path(config_yml).stem
         else:
             self.filename_prefix = None
 
+    @property
+    def default_style(self):
+        """ Sets the default style used in matplotlib figures        
+        """
+        if self._default_style is not None:
+            return self._default_style
+        else:
+            return 'default'
 
     @property
     def figure_formats(self):


### PR DESCRIPTION
The PR adds `default_style` as a property of reportengine.Environment. This implies that the same should be done, for instance, in `validphys`, meaning that the `default_style` property in validphys.app should be moved to validphys.config.Environment.