### PR TITLE
Update reportengine dependencies

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - blessings
     - pandoc >=2
     - dask
+    - distributed
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,6 @@ requirements:
     - python
     - flit
 
-
   run:
     - python
     - jinja2
@@ -25,7 +24,6 @@ requirements:
     - blessings
     - pandoc >=2
     - dask
-    - distributed
 
 test:
     requires:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,6 @@ test = [
     "pytest",
     "hypothesis",
 ]
-
+dashboard = [
+    "bokeh!=3.0.*,>=2.4.2"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires = [
     "pandas",
     "pygments",
     "blessings",
-    "dask",
+    "dask[distributed]",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 description-file="README.md"
 requires = [
     "jinja2",
-    "ruamel_yaml<0.18",
+    "ruamel_yaml<0.18", # the code is not compatible with ruamel 0.18
     "matplotlib",
     "pandas",
     "pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 description-file="README.md"
 requires = [
     "jinja2",
-    "ruamel_yaml",
+    "ruamel_yaml<0.18",
     "matplotlib",
     "pandas",
     "pygments",

--- a/src/reportengine/resourcebuilder.py
+++ b/src/reportengine/resourcebuilder.py
@@ -43,9 +43,9 @@ class DefaultStylePlugin(WorkerPlugin):
     Class used to set style for each dask worker
     """
 
-    def __init__(self, style, default_style):
-        self.style = style
-        self.default_style = default_style
+    def __init__(self, style = None, default_style = None):
+        self.style = style if style is not None else "default"
+        self.default_style = default_style if default_style is not None else "default"
 
     def setup(self, worker):
         from matplotlib import style
@@ -238,9 +238,12 @@ class ResourceExecutor:
         """
         log.info("Initializing dask.distributed Client")
 
-        plugin = DefaultStylePlugin(
-            style=self.environment.style, default_style=self.environment.default_style
-        )
+        if self.environment is not None:
+            plugin = DefaultStylePlugin(
+                style=self.environment.style, default_style=self.environment.default_style
+            )
+        else:
+            plugin = DefaultStylePlugin()
 
         if not scheduler:
             # the deefault distributed logger is too noisy. Limit it here since

--- a/src/reportengine/tests/test_builder.py
+++ b/src/reportengine/tests/test_builder.py
@@ -162,7 +162,8 @@ class TestBuilder(unittest.TestCase):
         d = namespaces.resolve(builder.rootns,  [('lists',1)])
         assert d['restaurant_collect'] == list("123")
         builder.execute_parallel()
-        assert namespaces.resolve(builder.rootns, ('UK',))['score'] == -1
+        # since it is using dask it returns a future
+        assert namespaces.resolve(builder.rootns, ('UK',))['score'].result() == -1
 
     def test_collect_raises(self):
         with self.assertRaises(TypeError):

--- a/src/reportengine/tests/test_executor.py
+++ b/src/reportengine/tests/test_executor.py
@@ -76,10 +76,13 @@ class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
         self.graph.add_node(mcall, inputs={gcall, hcall})
 
 
-    def _test_ns(self):
+    def _test_ns(self, promise=False):
         mresult = 'fresult: 4'*10
         namespace = self.rootns
-        self.assertEqual(namespace['mresult'], mresult)
+        if promise:
+            self.assertEqual(namespace['mresult'].result(), mresult)
+        else:
+            self.assertEqual(namespace['mresult'], mresult)
 
 
     def test_seq_execute(self):
@@ -88,7 +91,7 @@ class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
 
     def test_parallel_execute(self):
         self.execute_parallel()
-        self._test_ns()
+        self._test_ns(promise=True)
 
 if __name__ =='__main__':
     unittest.main()


### PR DESCRIPTION
This PR does:

- updates the `ruamel` and `dask` dependencies 

- Modify tests in `test_executor.py` and `test_builder.py` so as to be able to accept dask futures.