### PR TITLE
Improve test executor readability 

### DIFF
--- a/src/reportengine/resourcebuilder.py
+++ b/src/reportengine/resourcebuilder.py
@@ -303,6 +303,8 @@ class ResourceExecutor:
         # gather futures once all jobs have been submitted
         self.gather_results(leaf_callspecs, client)
 
+        return client
+
 
     def set_future(self, future, callspec):
         """

--- a/src/reportengine/tests/test_builder.py
+++ b/src/reportengine/tests/test_builder.py
@@ -161,9 +161,11 @@ class TestBuilder(unittest.TestCase):
         builder.resolve_fuzzytargets()
         d = namespaces.resolve(builder.rootns,  [('lists',1)])
         assert d['restaurant_collect'] == list("123")
-        builder.execute_parallel()
+        client = builder.execute_parallel()
         # since it is using dask it returns a future
         assert namespaces.resolve(builder.rootns, ('UK',))['score'].result() == -1
+        # close the client
+        client.close()
 
     def test_collect_raises(self):
         with self.assertRaises(TypeError):

--- a/src/reportengine/tests/test_executor.py
+++ b/src/reportengine/tests/test_executor.py
@@ -32,14 +32,6 @@ def m(gresult, hresult, param=None):
     print("executing m")
     return (gresult+hresult)*(param//2)
 
-def n(mresult):
-    return mresult
-
-def o(mresult):
-    return mresult*2
-
-def p(mresult):
-    return mresult*3
 
 class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
     def __init__(self, *args, **kwargs):

--- a/src/reportengine/tests/test_executor.py
+++ b/src/reportengine/tests/test_executor.py
@@ -41,7 +41,7 @@ def node_2_2(node_1_result):
 
 
 def node_3(node_2_1_result, node_2_2_result, param=None):
-    print("executing node_3")
+    print("Executing node_3")
     return (node_2_1_result + node_2_2_result) * (param // 2)
 
 
@@ -116,8 +116,9 @@ class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
         This test will execute the DAG in parallel, using
         dask distributed scheduler.
         """
-        self.execute_parallel()
+        client = self.execute_parallel()
         self._test_ns(promise=True)
+        client.close()
 
 
 if __name__ == "__main__":

--- a/src/reportengine/tests/test_executor.py
+++ b/src/reportengine/tests/test_executor.py
@@ -15,30 +15,34 @@ import time
 from reportengine.dag import DAG
 from reportengine.utils import ChainMap
 from reportengine import namespaces
-from reportengine.resourcebuilder import (ResourceExecutor, CallSpec)
+from reportengine.resourcebuilder import ResourceExecutor, CallSpec
 
 """
 Define some simple functions that will be used as nodes in the DAG.
 """
+
 
 def node_1(param):
     print("Executing node_1")
     time.sleep(0.1)
     return "node_1_result: %s" % param
 
+
 def node_2_1(node_1_result):
     print("Executing node_2_1")
     time.sleep(0.2)
-    return node_1_result*2
+    return node_1_result * 2
+
 
 def node_2_2(node_1_result):
     print("Executing node_2_2")
     time.sleep(0.2)
-    return node_1_result*3
+    return node_1_result * 3
+
 
 def node_3(node_2_1_result, node_2_2_result, param=None):
     print("executing node_3")
-    return (node_2_1_result+node_2_2_result)*(param//2)
+    return (node_2_1_result + node_2_2_result) * (param // 2)
 
 
 class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
@@ -57,46 +61,48 @@ class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
                         node_3
 
         """
-        self.rootns = ChainMap({'param':4, 'inner': {}})
+        self.rootns = ChainMap({"param": 4, "inner": {}})
+
         def nsspec(x, beginning=()):
             ns = namespaces.resolve(self.rootns, beginning)
-            default_label =  '_default' + str(x)
+            default_label = "_default" + str(x)
             namespaces.push_nslevel(ns, default_label)
             return beginning + (default_label,)
 
         self.graph = DAG()
 
-        node_1_call = CallSpec(node_1, ('param',), 'node_1_result',
-                         nsspec(node_1))
+        node_1_call = CallSpec(node_1, ("param",), "node_1_result", nsspec(node_1))
 
-        node_2_1_call = CallSpec(node_2_1, ('node_1_result',), 'node_2_1_result',
-                         nsspec(node_2_1))
+        node_2_1_call = CallSpec(
+            node_2_1, ("node_1_result",), "node_2_1_result", nsspec(node_2_1)
+        )
 
-        node_2_2_call = CallSpec(node_2_2, ('node_1_result',), 'node_2_2_result',
-                         nsspec(node_2_2))
+        node_2_2_call = CallSpec(
+            node_2_2, ("node_1_result",), "node_2_2_result", nsspec(node_2_2)
+        )
 
-        node_3_call = CallSpec(node_3, ('node_2_1_result','node_2_2_result','param'), 'node_3_result',
-                         nsspec(node_3))
-
-
+        node_3_call = CallSpec(
+            node_3,
+            ("node_2_1_result", "node_2_2_result", "param"),
+            "node_3_result",
+            nsspec(node_3),
+        )
 
         self.graph.add_node(node_1_call)
         self.graph.add_node(node_2_1_call, inputs={node_1_call})
         self.graph.add_node(node_2_2_call, inputs={node_1_call})
         self.graph.add_node(node_3_call, inputs={node_2_1_call, node_2_2_call})
 
-
     def _test_ns(self, promise=False):
         """
         Asserts that the namespace contains the expected results.
         """
-        node_3_result = 'node_1_result: 4'*10
+        node_3_result = "node_1_result: 4" * 10
         namespace = self.rootns
         if promise:
-            self.assertEqual(namespace['node_3_result'].result(), node_3_result)
+            self.assertEqual(namespace["node_3_result"].result(), node_3_result)
         else:
-            self.assertEqual(namespace['node_3_result'], node_3_result)
-
+            self.assertEqual(namespace["node_3_result"], node_3_result)
 
     def test_seq_execute(self):
         """
@@ -113,5 +119,6 @@ class TestResourceExecutor(unittest.TestCase, ResourceExecutor):
         self.execute_parallel()
         self._test_ns(promise=True)
 
-if __name__ =='__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR does:

- adds a return to the `execute_parallel` method in resource builder returning the client object (with close() method)

- renames some of the toy functions used to generate a toy DAG with diamond structure.

- adds some docstrings as well as remove some unused toy functions whose names were: `n`, `o`, `p`  

Note: client.close is needed by `test_executor` and `test_builder`. Otherwise if test_builder is pytested runned before the test_executor, test_executor will be stuck because the client has not been closed appropriately
