### PR TITLE
Add 3.9.2 to the conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,11 +11,11 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.9.2
     - flit
 
   run:
-    - python
+    - python >=3.9.2
     - jinja2
     - ruamel.yaml >=0.15
     - matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,11 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7"
+    "Programming Language :: Python :: 3.9"
 ]
 description-file="README.md"
 requires = [
+    "python>=3.9.2",
     "jinja2",
     "ruamel.yaml>=0.15",
     "matplotlib",


### PR DESCRIPTION
Turns out reportengine is not compatible with 3.9 due to dask:

```
Python 3.9.0 | packaged by conda-forge | (default, Nov 26 2020, 07:57:39)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reportengine
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/reportengine/__init__.py", line 7, in <module>
    from . resourcebuilder import collect
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/reportengine/resourcebuilder.py", line 25, in <module>
    from dask.distributed import Client, WorkerPlugin
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/dask/distributed.py", line 13, in <module>
    from distributed import *
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/distributed/__init__.py", line 23, in <module>
    from distributed.actor import Actor, ActorFuture, BaseActorFuture
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/distributed/actor.py", line 13, in <module>
    from distributed.client import Future
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/distributed/client.py", line 132, in <module>
    from distributed.worker import get_client, get_worker, secede
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/distributed/worker.py", line 119, in <module>
    from distributed.worker_memory import (
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/site-packages/distributed/worker_memory.py", line 56, in <module>
    WorkerDataParameter: TypeAlias = Union[
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/typing.py", line 243, in inner
    return func(*args, **kwds)
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/typing.py", line 316, in __getitem__
    return self._getitem(self, parameters)
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/typing.py", line 421, in Union
    parameters = _remove_dups_flatten(parameters)
  File "/home/jumax9/Workspace/conda/pixi_python39/.pixi/envs/default/lib/python3.9/typing.py", line 215, in _remove_dups_flatten
    all_params = set(params)
TypeError: unhashable type: 'list'
```

https://github.com/dask/distributed/issues/7956 i think it makes sense to add it to the recipes