### PR TITLE
Handle zero or non-finite error in __str__ method

### DIFF
--- a/src/reportengine/floatformatting.py
+++ b/src/reportengine/floatformatting.py
@@ -83,5 +83,8 @@ class ValueErrorTuple(NamedTuple):
     value: numbers.Real
     error: numbers.Real
     def __str__(self):
+        if self.error == 0 or not np.isfinite(np.log10(self.error)):
+            value = int(self.value) if self.value == int(self.value) else round(self.value, 4)
+            return f'{value}±0'
         valstr, errstr = format_value_error(self.value, self.error)
         return f'{valstr}±{errstr}'

--- a/src/reportengine/floatformatting.py
+++ b/src/reportengine/floatformatting.py
@@ -84,6 +84,8 @@ class ValueErrorTuple(NamedTuple):
     error: numbers.Real
     def __str__(self):
         if self.error == 0 or not np.isfinite(np.log10(self.error)):
+            if not np.isfinite(self.value):
+                return f'{self.value}±0'
             value = int(self.value) if self.value == int(self.value) else round(self.value, 4)
             return f'{value}±0'
         valstr, errstr = format_value_error(self.value, self.error)


### PR DESCRIPTION
Relevant fix when working with Bayesian Neural networks  which by construction gets std=0 for some validphys quantities